### PR TITLE
fix: excessive debug logging of big JSON blob

### DIFF
--- a/lastejobb.js
+++ b/lastejobb.js
@@ -11,7 +11,8 @@ switch (argLast) {
     init.init();
 }
 
-if (!process.env.DEBUG) process.env.DEBUG = "*";
+// By default, ignore the long noisy JSON debug logs from axios library follow-redirects
+if (!process.env.DEBUG) process.env.DEBUG = "*,-follow-redirects";
 if (process.argv.length === 3) {
   const scripPath = process.argv[2];
   if (!io.directoryExists(scripPath)) {

--- a/lib/dockerops.js
+++ b/lib/dockerops.js
@@ -1,6 +1,5 @@
 const execSync = require("child_process").execSync;
 
-
     function run_in_shell(cmd) {// : string
         const out = execSync(cmd, { skipThrow: false });
         const out_string = new TextDecoder('utf-8').decode(out);
@@ -12,6 +11,7 @@ const execSync = require("child_process").execSync;
         let d = new Date().getTime();
         return name+d;
     }
+
     //Will substitute start_ogr_containername as this takes a folder on the host as an argument, making it more flexible
     function start_gdal(name, srcFolder){
         let hostPath=process.env.PWD + '/' + srcFolder + '/';
@@ -20,7 +20,6 @@ const execSync = require("child_process").execSync;
         console.log(name);
         return name;
     }
-
 
     function start_ogr_containerNImage(name){// : void
         let tempPath=process.env.PWD + '/temp/';
@@ -34,7 +33,6 @@ const execSync = require("child_process").execSync;
     function clean_container (container_name){// : void
         run_in_shell(`docker rm -f ${container_name}`);
     }
-
 
     function exec_docker(name, cmd){
         const wholecmd = `docker exec -i ${name} sh -c "${cmd}"`;   


### PR DESCRIPTION
Slår som standard av logging fra follow-redirects biblioteket som er brukt av axios.  Det er mulig å slå det på ved behov ved å overstyre DEBUG miljøvariabel før oppstart til f.eks. DEBUG=*

Årsak: Den logger store JSON objekter som gjør det vanskelig å lese loggen.

Loggen ser slik ut hver gang en http request gjøres:

```
  ℹssb_kommune Download http://data.ssb.no/api/klass/v1/classifications/131/codes.json?from=2023-08-27&to=2023-08-28 +0ms
follow-redirects options {
  maxRedirects: 21,
  maxBodyLength: Infinity,
  protocol: 'https:',
  path: '/api/klass/v1/versions/916.json?language=nb',
  method: 'GET',
  headers: [Object: null prototype] {
    Accept: 'application/json, text/plain, */*',
    'User-Agent': 'axios/1.4.0',
    'Accept-Encoding': 'gzip, compress, deflate, br'
  },
  agents: { http: undefined, https: undefined },
  auth: undefined,
  family: undefined,
  lookup: undefined,
  beforeRedirect: [Function: dispatchBeforeRedirect],
  beforeRedirects: { proxy: [Function: beforeRedirect] },
  hostname: 'data.ssb.no',
  port: '',
  agent: undefined,
  nativeProtocols: {
    'http:': {
      _connectionListener: [Function: connectionListener],
      METHODS: [Array],
      STATUS_CODES: [Object],
      Agent: [Function],
      ClientRequest: [Function: ClientRequest],
      IncomingMessage: [Function: IncomingMessage],
      OutgoingMessage: [Function: OutgoingMessage],
      Server: [Function: Server],
      ServerResponse: [Function: ServerResponse],
      createServer: [Function: createServer],
      validateHeaderName: [Function: __node_internal_],
      validateHeaderValue: [Function: __node_internal_],
      get: [Function: get],
      request: [Function: request],
      maxHeaderSize: [Getter],
      globalAgent: [Getter/Setter]
    },
    'https:': {
      Agent: [Function: Agent],
      globalAgent: [Agent],
      Server: [Function: Server],
      createServer: [Function: createServer],
      get: [Function: get],
      request: [Function: request]
    }
  }
} +0ms
``