### PR TITLE
fix: csv parse throws error

### DIFF
--- a/lib/csv.js
+++ b/lib/csv.js
@@ -1,5 +1,4 @@
-//const parse = require("csv-parse/lib/sync");
-const parse = require('csv-parse/sync')
+const { parse } = require('csv-parse/sync')
 const fs = require("fs");
 
 /**

--- a/package.json
+++ b/package.json
@@ -34,5 +34,5 @@
   "scripts": {
     "test": "export DEBUG=*,-follow-redirects,-jest* jest && jest"
   },
-  "version": "4.0.11"
+  "version": "4.0.12"
 }


### PR DESCRIPTION
natursystem-lastejobb feiler ved kjøring etter oppgradering av csv-bibliotek gjort i januar.

parse-funksjonen fra biblioteket er i ny versjon ikke lenger eksportert med "export default" og må derfor ha curly brackets rundt seg.

Gammel kode i csv-parse biblioteket:

```javascript
export default parse
```

Ny versjon: 
```javascript
export { parse, Parser, CsvError };
```


